### PR TITLE
Removed the main tag from package.json and change the start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "bengoshi",
   "version": "1.0.0",
   "description": "AO2 Server",
-  "main": "Server.js",
   "dependencies": {
     "ini-parser": "0.0.2",
     "js-yaml": "^3.12.0"
@@ -10,7 +9,7 @@
   "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js"
+    "start": "node Server.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I know the readme says to use `npm start` but it would also be nice to have `npm run start` work as well. 

Script originally had `server.js` when the file was named `Server.js`, just updated the file so it works with
`npm start` && `npm run start`

Some light reading if you're feeling spicy:
https://docs.npmjs.com/cli/run-script
https://stackoverflow.com/questions/51358235/difference-between-npm-start-and-npm-run-start
(This is probably more of a feature? But whatever)